### PR TITLE
validate params middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,20 @@ Example usage:
 ```
 testLogger, testStatsd := tools.NewTestTools(t)
 ```
+
+## httputil.ValidateParamsHandler
+
+Example:
+
+```
+type MainHandler struct{}
+
+func (mh MainHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprint(w, "Hello world\n")
+}
+
+func main() {
+	http.Handle("/", httputil.ValidateParamsHandler(MainHandler{}, "X-Component", "X-User-ID"))
+	http.ListenAndServe(":8080", nil)
+}
+```

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,0 +1,44 @@
+package http
+
+import "net/http"
+import "errors"
+import (
+	"fmt"
+	"strings"
+)
+
+// Validate verifies that all strings passed as `params` are present as keys in req.Header.
+// An error listing the missing params is returned if at least one param is missing.
+func Validate(params []string, req *http.Request) error {
+	missing := getMissingKeys(req, params)
+	if len(missing) == 0 {
+		return nil
+	}
+	return errors.New("The following required params are missing from the request (as headers) : " + strings.Join(missing, ","))
+}
+
+// ValidateParamsHandler wraps a http.Handler with validation to check if the specified params are
+// supplied as HTTP headers.
+// If not, a 400 is returned with a list of the missing params.
+// If all required params supplied, the supplied handler is called transparently.
+func ValidateParamsHandler(h http.Handler, params ...string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		err := Validate(params, req)
+		if err != nil {
+			w.WriteHeader(400)
+			fmt.Fprintf(w, err.Error())
+			return
+		}
+		h.ServeHTTP(w, req)
+	})
+}
+
+func getMissingKeys(req *http.Request, required []string) []string {
+	missing := []string{}
+	for _, param := range required {
+		if req.Header.Get(param) == "" {
+			missing = append(missing, param)
+		}
+	}
+	return missing
+}

--- a/httputil/httputil_test.go
+++ b/httputil/httputil_test.go
@@ -1,0 +1,102 @@
+package http
+
+import "testing"
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+)
+
+func TestValidate_ReturnsErrorWhenNoRequiredParamsSupplied(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("Content-Type", "application/json")
+
+	err := Validate([]string{"Required-One", "Required-Two"}, req)
+
+	notAsExpected := err == nil ||
+		!strings.Contains(err.Error(), "Required-One") ||
+		!strings.Contains(err.Error(), "Required-Two")
+	if notAsExpected {
+		t.Error("Expected error listing Required-One and Required-Two")
+	}
+}
+
+func TestValidate_ReturnsNoErrorWhenAllRequiredParamsSupplied(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+	req.Header.Add("Required-Two", "something")
+	req.Header.Add("Required-One", "something-else")
+	req.Header.Add("Other-Header", "not-relevant")
+
+	err := Validate([]string{"Required-One", "Required-Two"}, req)
+
+	if err != nil {
+		t.Error("Expected no errors as both required params are present")
+	}
+
+}
+
+type TestHandler struct{}
+
+func (h TestHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprint(w, "Hello from TestHandler")
+}
+
+func TestValidateParamsHandler_RequiredParamsPassed(t *testing.T) {
+	testHandler := TestHandler{}
+	testHandlerWithValidation := ValidateParamsHandler(testHandler, "Required-One", "Required-Two")
+
+	ts := httptest.NewServer(testHandlerWithValidation)
+	defer ts.Close()
+
+	client := &http.Client{}
+	req := httptest.NewRequest("GET", ts.URL, nil)
+	req.RequestURI = ""
+	req.Header.Add("Required-Two", "something")
+	req.Header.Add("Required-One", "something-else")
+	req.Header.Add("Other-Header", "not-relevant")
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		t.Error(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected status code 200 but got %d", resp.StatusCode)
+	}
+}
+
+func TestValidateParamsHandler_SomeRequiredParamsMissing(t *testing.T) {
+	testHandler := TestHandler{}
+	testHandlerWithValidation := ValidateParamsHandler(testHandler, "Required-One", "Required-Two", "Required-Three")
+
+	ts := httptest.NewServer(testHandlerWithValidation)
+	defer ts.Close()
+
+	client := &http.Client{}
+	req := httptest.NewRequest("GET", ts.URL, nil)
+	req.RequestURI = ""
+	req.Header.Add("Required-Two", "something")
+	req.Header.Add("Required-One", "something-else")
+	req.Header.Add("Other-Header", "not-relevant")
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		t.Error(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("Expected status code 400 but got %d", resp.StatusCode)
+	}
+	bodybytes, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	body := string(bodybytes)
+	fmt.Println(body)
+	if !strings.Contains(body, "Required-Three") {
+		t.Error("Should have error message with 'Required-Three' in the response body")
+	}
+	if strings.Contains(body, "Required-One") || strings.Contains(body, "Required-Two") {
+		t.Error("Should not have 'Required-One' or 'Required-Two' in the response body")
+	}
+}


### PR DESCRIPTION
Check for specific headers, and send a 400 if they're not present.
Can wrap existing handlers with this behaviour.