### PR TITLE
update gas reference to gosec for gometalinter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.9
 
 RUN go get -u github.com/alecthomas/gometalinter
 RUN go get -u github.com/kardianos/govendor
-RUN go get -u github.com/HewlettPackard/gas
+RUN go get -u github.com/securego/gosec
 RUN go get -u github.com/stretchr/testify/assert
 RUN go get -u github.com/kyoh86/richgo
 RUN gometalinter --install


### PR DESCRIPTION
github.com/HewlettPackard/gas was renamed to github.com/securego/gosec 
we need to reflect gometalinter update
https://github.com/alecthomas/gometalinter/commit/445bce7956d2cd3b792db2ce3323d4fd31aa7d80i