### PR TITLE
pretty sure the logger has been broken for a while

### DIFF
--- a/http-handler-with-stats.go
+++ b/http-handler-with-stats.go
@@ -6,14 +6,8 @@ import (
 	"net/http"
 )
 
-type logger interface {
-	Debug(...interface{})
-	Info(...interface{})
-	Error(...interface{})
-}
-
 // HTTPHandlerWithStats takes an http.Handler and adds the sending of response time metrics to DataDog, and debug logging of request details
-func HTTPHandlerWithStats(routeName string, router http.Handler, logger logger, statsd StatsD) http.Handler {
+func HTTPHandlerWithStats(routeName string, router http.Handler, logger Logger, statsd StatsD) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Debug(r.Method, "at", r.URL.String())
 		metrics := httpsnoop.CaptureMetrics(router, w, r)
@@ -22,7 +16,7 @@ func HTTPHandlerWithStats(routeName string, router http.Handler, logger logger, 
 	})
 }
 
-func logResult(routeName string, metrics httpsnoop.Metrics, statsd StatsD, logger logger, req *http.Request) {
+func logResult(routeName string, metrics httpsnoop.Metrics, statsd StatsD, logger Logger, req *http.Request) {
 	responseTag := fmt.Sprintf("response:%d", metrics.Code)
 	tags := []string{"route:" + routeName, responseTag}
 	if caller := req.Header.Get("X-Component"); caller != "" {
@@ -31,5 +25,5 @@ func logResult(routeName string, metrics httpsnoop.Metrics, statsd StatsD, logge
 	statsd.Histogram(WebResponseTimeKey, float64(metrics.Duration.Nanoseconds())/1000000, tags...)
 	statsd.Incr(fmt.Sprintf(WebResponseCodeFormatKey, metrics.Code), tags...)
 	statsd.Incr(WebResponseCodeAllKey, tags...)
-	logger.Debug("Request to", req.URL.String(), "had response code", metrics.Code)
+	logger.Debugf("Request to %s had response code %d", req.URL.String(), metrics.Code)
 }

--- a/http-handler-with-stats.go
+++ b/http-handler-with-stats.go
@@ -25,5 +25,5 @@ func logResult(routeName string, metrics httpsnoop.Metrics, statsd StatsD, logge
 	statsd.Histogram(WebResponseTimeKey, float64(metrics.Duration.Nanoseconds())/1000000, tags...)
 	statsd.Incr(fmt.Sprintf(WebResponseCodeFormatKey, metrics.Code), tags...)
 	statsd.Incr(WebResponseCodeAllKey, tags...)
-	logger.Debugf("Request to %s had response code %d", req.URL.String(), metrics.Code)
+	logger.Debugf("Request to %s had response code %d in %dms", req.URL.String(), metrics.Code, metrics.Duration.Milliseconds())
 }

--- a/http-handler-with-stats_test.go
+++ b/http-handler-with-stats_test.go
@@ -45,7 +45,7 @@ func TestHTTPHandlerWithStats(t *testing.T) {
 
 	assert.NotNil(t, lastLogCall, "Expected call to be made")
 	assert.Equal(t, "Debug", lastLogCall.Method)
-	assert.Equal(t, "[Request to http://example.com had response code 200]", lastLogCall.Args.Msg)
+	assert.Equal(t, "Request to http://example.com had response code 200", lastLogCall.Args.Msg)
 
 	checkMetricsCalled(t, statsd, "route", http.StatusOK, "200")
 
@@ -63,7 +63,7 @@ func TestHTTPHandlerWithStats_Error(t *testing.T) {
 
 	assert.NotNil(t, lastLogCall, "Expected call to be made")
 	assert.Equal(t, "Debug", lastLogCall.Method)
-	assert.Equal(t, "[Request to http://example.com had response code 500]", lastLogCall.Args.Msg)
+	assert.Equal(t, "Request to http://example.com had response code 500", lastLogCall.Args.Msg)
 
 	checkMetricsCalled(t, statsd, "route", http.StatusInternalServerError, "500")
 }

--- a/http-handler-with-stats_test.go
+++ b/http-handler-with-stats_test.go
@@ -45,7 +45,7 @@ func TestHTTPHandlerWithStats(t *testing.T) {
 
 	assert.NotNil(t, lastLogCall, "Expected call to be made")
 	assert.Equal(t, "Debug", lastLogCall.Method)
-	assert.Equal(t, "Request to http://example.com had response code 200", lastLogCall.Args.Msg)
+	assert.Equal(t, "Request to http://example.com had response code 200 in 0ms", lastLogCall.Args.Msg)
 
 	checkMetricsCalled(t, statsd, "route", http.StatusOK, "200")
 
@@ -63,7 +63,7 @@ func TestHTTPHandlerWithStats_Error(t *testing.T) {
 
 	assert.NotNil(t, lastLogCall, "Expected call to be made")
 	assert.Equal(t, "Debug", lastLogCall.Method)
-	assert.Equal(t, "Request to http://example.com had response code 500", lastLogCall.Args.Msg)
+	assert.Equal(t, "Request to http://example.com had response code 500 in 0ms", lastLogCall.Args.Msg)
 
 	checkMetricsCalled(t, statsd, "route", http.StatusInternalServerError, "500")
 }

--- a/internal.go
+++ b/internal.go
@@ -14,7 +14,7 @@ func InternalHealthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 // InternalLogConfig creates an http handler which logs out the app's config
-func InternalLogConfig(config interface{}, logger logger) http.HandlerFunc {
+func InternalLogConfig(config interface{}, logger Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger.Info(fmt.Sprintf("Application config - %+v", config))
 		fmt.Fprint(w, "Logged the config")

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"os"
 	"runtime"
@@ -10,9 +11,13 @@ import (
 
 type Logger interface {
 	Info(msg ...interface{})
+	Infof(format string, a ...interface{})
 	Error(msg ...interface{})
+	Errorf(format string, a ...interface{})
 	Debug(msg ...interface{})
+	Debugf(format string, a ...interface{})
 	Warn(msg ...interface{})
+	Warnf(format string, a ...interface{})
 }
 
 // Logger logs messages in a structured format in prod and pretty colours in local.
@@ -23,22 +28,42 @@ type logrusLogger struct {
 
 // Info should be used to log key application events.
 func (l *logrusLogger) Info(msg ...interface{}) {
-	l.log.WithFields(withFileAndLine(l.fields)).Info(msg)
+	l.log.WithFields(withFileAndLine(l.fields)).Info(msg...)
+}
+
+// Infof logs key application events with a format (like fmt)
+func (l *logrusLogger) Infof(format string, a ...interface{}) {
+	l.Info(fmt.Sprintf(format, a...))
 }
 
 // Error should be used to log events that need to be actioned on immediately.
 func (l *logrusLogger) Error(msg ...interface{}) {
-	l.log.WithFields(withFileAndLine(l.fields)).Error(msg)
+	l.log.WithFields(withFileAndLine(l.fields)).Error(msg...)
+}
+
+// Errorf should be used to log events that need to be actioned on immediately
+func (l *logrusLogger) Errorf(format string, a ...interface{}) {
+	l.Error(fmt.Sprintf(format, a...))
 }
 
 // Debug can be used to log events for local development.
 func (l *logrusLogger) Debug(msg ...interface{}) {
-	l.log.WithFields(withFileAndLine(l.fields)).Debug(msg)
+	l.log.WithFields(withFileAndLine(l.fields)).Debug(msg...)
+}
+
+// Debugf can be used to log events for local development.
+func (l *logrusLogger) Debugf(format string, a ...interface{}) {
+	l.Debug(fmt.Sprintf(format, a...))
 }
 
 // Warn is for when something bad happened but doesnt need instant action.
 func (l *logrusLogger) Warn(msg ...interface{}) {
-	l.log.WithFields(withFileAndLine(l.fields)).Warn(msg)
+	l.log.WithFields(withFileAndLine(l.fields)).Warn(msg...)
+}
+
+// Warnf is for when something bad happened but doesnt need instant action.
+func (l *logrusLogger) Warnf(format string, a ...interface{}) {
+	l.Warn(fmt.Sprintf(format, a...))
 }
 
 func withFileAndLine(fields logrus.Fields) logrus.Fields {
@@ -74,15 +99,13 @@ func NewLogger(isLocal bool) Logger {
 	}
 
 	if !isLocal {
-		logrus.SetFormatter(
-			&logrus.JSONFormatter{
-				TimestampFormat: time.RFC3339Nano,
-				FieldMap: logrus.FieldMap{
-					logrus.FieldKeyTime: "timestamp",
-					logrus.FieldKeyMsg:  "message",
-				},
+		logger.Formatter = &logrus.JSONFormatter{
+			TimestampFormat: time.RFC3339Nano,
+			FieldMap: logrus.FieldMap{
+				logrus.FieldKeyTime: "timestamp",
+				logrus.FieldKeyMsg:  "message",
 			},
-		)
+		}
 	}
 
 	return &logrusLogger{

--- a/mock_logger.go
+++ b/mock_logger.go
@@ -23,17 +23,42 @@ type LoggerArgs struct {
 
 // Info is a mock info method
 func (ml *MockLogger) Info(args ...interface{}) {
-	ml.call("Info", args)
+	ml.call("Info", args...)
+}
+
+// Infof is a mock info method
+func (ml *MockLogger) Infof(format string, args ...interface{}) {
+	ml.call("Info", fmt.Sprintf(format, args...))
 }
 
 // Info is a mock info method
 func (ml *MockLogger) Error(args ...interface{}) {
-	ml.call("Error", args)
+	ml.call("Error", args...)
+}
+
+// Errorf is a mock info method
+func (ml *MockLogger) Errorf(format string, args ...interface{}) {
+	ml.call("Error", fmt.Sprintf(format, args...))
 }
 
 // Debug is a mock debug method
 func (ml *MockLogger) Debug(args ...interface{}) {
-	ml.call("Debug", args)
+	ml.call("Debug", args...)
+}
+
+// Debugf is a mock debug method
+func (ml *MockLogger) Debugf(format string, args ...interface{}) {
+	ml.call("Debug", fmt.Sprintf(format, args...))
+}
+
+// Warn is a mock debug method
+func (ml *MockLogger) Warn(args ...interface{}) {
+	ml.call("Warn", args...)
+}
+
+// Warnf is a mock debug method
+func (ml *MockLogger) Warnf(format string, args ...interface{}) {
+	ml.call("Warn", fmt.Sprintf(format, args...))
 }
 
 func (ml *MockLogger) Call() (c LoggerCall, err error) {

--- a/testlogger.go
+++ b/testlogger.go
@@ -2,6 +2,7 @@ package tools
 
 type T interface {
 	Log(args ...interface{})
+	Logf(format string, args ...interface{})
 }
 
 // TestLogger accepts the testing package so you wont be bombarded with logs
@@ -15,9 +16,19 @@ func (testLogger TestLogger) Info(msg ...interface{}) {
 	testLogger.T.Log("[Info]", msg)
 }
 
+// Infof logs info to the test logger.
+func (testLogger TestLogger) Infof(format string, msg ...interface{}) {
+	testLogger.T.Logf("[Info] "+format, msg)
+}
+
 // Debug logs debug to the test logger.
 func (testLogger TestLogger) Debug(msg ...interface{}) {
 	testLogger.T.Log("[Debug]", msg)
+}
+
+// Debugf logs debug to the test logger.
+func (testLogger TestLogger) Debugf(format string, msg ...interface{}) {
+	testLogger.T.Log("[Debug] "+format, msg)
 }
 
 // Error logs error to the test logger.
@@ -25,7 +36,17 @@ func (testLogger TestLogger) Error(msg ...interface{}) {
 	testLogger.T.Log("[Error]", msg)
 }
 
+// Errorf logs error to the test logger.
+func (testLogger TestLogger) Errorf(format string, msg ...interface{}) {
+	testLogger.T.Log("[Error] "+format, msg)
+}
+
 // Warn logs warn to the test logger.
 func (testLogger TestLogger) Warn(msg ...interface{}) {
 	testLogger.T.Log("[Warn]", msg)
+}
+
+// Warnf logs warn to the test logger.
+func (testLogger TestLogger) Warnf(format string, msg ...interface{}) {
+	testLogger.T.Log("[Warn] "+format, msg)
 }


### PR DESCRIPTION
If you look down the PR a bit

I replaced `logrus.SetFormatter(` with  `logger.Formatter = &logrus.JSONFormatter{`

I'm pretty sure the former was configuring the global logger which we don't use. Which is why our logs are not formatting correctly.

I've also added `f` methods for all of the log things for convenience